### PR TITLE
Update types with a clearer API, and fix compile issues

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,9 +1,11 @@
-package gateway
+package api
 
 import (
 	"context"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-fetcher"
+	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipld/go-ipld-prime"
 )
 
@@ -17,7 +19,23 @@ type API interface {
 	// FetcherForSession describes dags that that the session is requesting to load. These dags should
 	// be fetchd into the local linksystem if not already present.
 	FetcherForSession(*ipld.LinkSystem) fetcher.Fetcher
+	// GetUnixFSNode requests a unixfs file or directory. This could be requested through a fetcher,
+	// but our fetcher paths do not currently support parallel fetchign or pre-loading of files.
+	GetUnixFSNode(*ipld.LinkSystem, cid.Cid) (files.Node, error)
+	// GetUnixFSDir requests the entries of a unixfs directories. This eventaully should be an
+	// API on the go-ipfs-files interface, but is included here explictly until all implementations
+	// support it directly on Directory objects.
+	GetUnixFSDir(*ipld.LinkSystem, files.Directory) ([]DirectoryItem, error)
 	// Resolver requests resolutions of dns names, and acts as an interface over go-namesys.
 	// If resolution is not supported, the name argument should be returned directly.
 	Resolve(ctx context.Context, name string) (string, error)
+}
+
+// DirectoryItem defines an entry in a UnixFS directory.
+type DirectoryItem interface {
+	GetSize() string
+	GetName() string
+	GetPath() string
+	GetHash() string
+	GetShortHash() string
 }

--- a/commands.go
+++ b/commands.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"path/filepath"
+	"os"
 	"strings"
+
+	"github.com/ipfs-shipyard/gateway-prime/api"
 )
 
 // APIPath is the path at which the API is mounted.
@@ -16,15 +18,41 @@ var (
 	errAPIVersionMismatch = errors.New("api version mismatch")
 )
 
+var defaultLocalhostOrigins = []string{
+	"http://127.0.0.1:<port>",
+	"https://127.0.0.1:<port>",
+	"http://[::1]:<port>",
+	"https://[::1]:<port>",
+	"http://localhost:<port>",
+	"https://localhost:<port>",
+}
+
+var companionBrowserExtensionOrigins = []string{
+	"chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch", // ipfs-companion
+	"chrome-extension://hjoieblefckbooibpepigmacodalfndh", // ipfs-companion-beta
+}
+
+func commandsOption(handler http.Handler) ServeOption {
+	return func(_ api.API, gc *GatewayConfig, l net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+		mux.Handle(APIPath+"/", handler)
+		return mux, nil
+	}
+}
+
+// CommandsOption constructs a ServerOption for hooking an additional endpoint into the
+// HTTP server.
+func CommandsOption(handler http.Handler) ServeOption {
+	return commandsOption(handler)
+}
+
 // CheckVersionOption returns a ServeOption that checks whether the client ipfs version matches. Does nothing when the user agent string does not contain `/go-ipfs/`
 func CheckVersionOption(daemonVersion string) ServeOption {
-	return ServeOption(func(_ API, _ *GatewayConfig, l net.Listener, parent *http.ServeMux) (*http.ServeMux, error) {
+	return ServeOption(func(_ api.API, _ *GatewayConfig, l net.Listener, parent *http.ServeMux) (*http.ServeMux, error) {
 		mux := http.NewServeMux()
 		parent.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasPrefix(r.URL.Path, APIPath) {
 				cmdqry := r.URL.Path[len(APIPath):]
-				pth := filepath.SplitList(cmdqry)
-
+				pth := strings.Split(cmdqry, string(os.PathSeparator))
 				// backwards compatibility to previous version check
 				if len(pth) >= 2 && pth[1] != "version" {
 					clientVersion := r.UserAgent()

--- a/config.go
+++ b/config.go
@@ -67,4 +67,15 @@ type GatewayConfig struct {
 	// PublicGateways configures behavior of known public gateways.
 	// Each key is a fully qualified domain name (FQDN).
 	PublicGateways map[string]*GatewaySpec
+
+	// FastDirIndexThreshold defines a threshold of directory size under which
+	// the direct children of the directory will be loaded in order to provide
+	// more details (like the number of items in child directories).
+	FastDirIndexThreshold int
+}
+
+func setConfigDefaults(gc *GatewayConfig) {
+	if gc.FastDirIndexThreshold == 0 {
+		gc.FastDirIndexThreshold = 100
+	}
 }

--- a/gateway.go
+++ b/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/ipfs-shipyard/gateway-prime/api"
 	id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
@@ -15,7 +16,7 @@ import (
 // It returns the mux to expose to future options, which may be a new mux if it
 // is interested in mediating requests to future options, or the same mux
 // initially passed in if not.
-type ServeOption func(API, *GatewayConfig, net.Listener, *http.ServeMux) (*http.ServeMux, error)
+type ServeOption func(api.API, *GatewayConfig, net.Listener, *http.ServeMux) (*http.ServeMux, error)
 
 // A helper function to clean up a set of headers:
 // 1. Canonicalizes.
@@ -38,7 +39,7 @@ func cleanHeaderSet(headers []string) []string {
 }
 
 func GatewayOption(paths ...string) ServeOption {
-	return func(a API, cfg *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(a api.API, cfg *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		headers := make(map[string][]string, len(cfg.HTTPHeaders))
 		for h, v := range cfg.HTTPHeaders {
 			headers[http.CanonicalHeaderKey(h)] = v
@@ -84,7 +85,7 @@ func GatewayOption(paths ...string) ServeOption {
 }
 
 func VersionOption(UserAgentVersion, CurrentCommit string) ServeOption {
-	return func(a API, cfg *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(a api.API, cfg *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Commit: %s\n", CurrentCommit)
 			fmt.Fprintf(w, "Client Version: %s\n", UserAgentVersion)
@@ -96,7 +97,7 @@ func VersionOption(UserAgentVersion, CurrentCommit string) ServeOption {
 
 // makeHandler turns a list of ServeOptions into a http.Handler that implements
 // all of the given options, in order.
-func makeHandler(a API, gc *GatewayConfig, l net.Listener, options ...ServeOption) (http.Handler, error) {
+func makeHandler(a api.API, gc *GatewayConfig, l net.Listener, options ...ServeOption) (http.Handler, error) {
 	topMux := http.NewServeMux()
 	mux := topMux
 	for _, option := range options {
@@ -125,7 +126,7 @@ func makeHandler(a API, gc *GatewayConfig, l net.Listener, options ...ServeOptio
 // TODO intelligently parse address strings in other formats so long as they
 // unambiguously map to a valid multiaddr. e.g. for convenience, ":8080" should
 // map to "/ip4/0.0.0.0/tcp/8080".
-func ListenAndServe(a API, gc *GatewayConfig, listeningMultiAddr string, options ...ServeOption) (*http.Server, error) {
+func ListenAndServe(a api.API, gc *GatewayConfig, listeningMultiAddr string, options ...ServeOption) (*http.Server, error) {
 	addr, err := ma.NewMultiaddr(listeningMultiAddr)
 	if err != nil {
 		return nil, err
@@ -145,9 +146,8 @@ func ListenAndServe(a API, gc *GatewayConfig, listeningMultiAddr string, options
 
 // Serve accepts incoming HTTP connections on the listener and pass them
 // to ServeOption handlers.
-func Serve(a API, gc *GatewayConfig, lis net.Listener, options ...ServeOption) *http.Server {
-	// make sure we close this no matter what.
-	//defer lis.Close()
+func Serve(a api.API, gc *GatewayConfig, lis net.Listener, options ...ServeOption) *http.Server {
+	setConfigDefaults(gc)
 
 	handler, err := makeHandler(a, gc, lis, options...)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.18
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.1
+	github.com/dustin/go-humanize v1.0.0
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-fetcher v1.6.1
+	github.com/ipfs/go-ipfs-files v0.0.3
 	github.com/ipfs/go-log v1.0.5
 	github.com/ipfs/go-path v0.3.0
 	github.com/ipfs/go-unixfsnode v1.4.1-0.20220502093700-f664db4b2168

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUn
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -421,6 +422,7 @@ github.com/ipfs/go-ipfs-exchange-interface v0.1.0/go.mod h1:ych7WPlyHqFvCi/uQI48
 github.com/ipfs/go-ipfs-exchange-offline v0.0.1/go.mod h1:WhHSFCVYX36H/anEKQboAzpUws3x7UeEGkzQc3iNkM0=
 github.com/ipfs/go-ipfs-exchange-offline v0.1.1 h1:mEiXWdbMN6C7vtDG21Fphx8TGCbZPpQnz/496w/PL4g=
 github.com/ipfs/go-ipfs-exchange-offline v0.1.1/go.mod h1:vTiBRIbzSwDD0OWm+i3xeT0mO7jG2cbJYatp3HPk5XY=
+github.com/ipfs/go-ipfs-files v0.0.3 h1:ME+QnC3uOyla1ciRPezDW0ynQYK2ikOh9OCKAEg4uUA=
 github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-posinfo v0.0.1/go.mod h1:SwyeVP+jCwiDu0C313l/8jg6ZxM0qqtlt2a0vILTc1A=
 github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=

--- a/hostname.go
+++ b/hostname.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ipfs-shipyard/gateway-prime/api"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/miekg/dns"
@@ -31,7 +32,7 @@ const dnsLabelMaxLength int = 63
 
 // HostnameOption rewrites an incoming request based on the Host header.
 func HostnameOption() ServeOption {
-	return func(a API, gc *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(a api.API, gc *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		childMux := http.NewServeMux()
 
 		knownGateways := prepareKnownGateways(gc.PublicGateways)
@@ -301,7 +302,7 @@ func isDomainNameAndNotPeerID(hostname string) bool {
 }
 
 // isDNSLinkName returns bool if a valid DNS TXT record exist for provided host
-func isDNSLinkName(ctx context.Context, api API, host string) bool {
+func isDNSLinkName(ctx context.Context, api api.API, host string) bool {
 	dnslinkName := stripPort(host)
 
 	if !isDomainNameAndNotPeerID(dnslinkName) {
@@ -385,7 +386,7 @@ func toDNSLinkFQDN(dnsLabel string) (fqdn string) {
 }
 
 // Converts a hostname/path to a subdomain-based URL, if applicable.
-func toSubdomainURL(hostname, path string, r *http.Request, a API) (redirURL string, err error) {
+func toSubdomainURL(hostname, path string, r *http.Request, a api.API) (redirURL string, err error) {
 	var scheme, ns, rootID, rest string
 
 	query := r.URL.RawQuery

--- a/hostname_test.go
+++ b/hostname_test.go
@@ -19,7 +19,7 @@ func TestToSubdomainURL(t *testing.T) {
 	sys := mock.API{}
 	sys.Resolver = ns
 	ls := sys.NewSession(context.Background())
-	lnk, err := ls.Store(ipld.LinkContext{}, cidlink.LinkPrototype{}, basicnode.NewString("hello world"))
+	lnk, err := ls.Store(ipld.LinkContext{}, basicLinkProto, basicnode.NewString("hello world"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logs.go
+++ b/logs.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/ipfs-shipyard/gateway-prime/api"
 	lwriter "github.com/ipfs/go-log/writer"
 )
 
@@ -44,7 +45,7 @@ func (w *writeErrNotifier) Close() error {
 }
 
 func LogOption() ServeOption {
-	return func(_ API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ api.API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
 			wnf, errs := newWriteErrNotifier(w)

--- a/metrics.go
+++ b/metrics.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
+	"github.com/ipfs-shipyard/gateway-prime/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opencensus.io/stats/view"
@@ -14,7 +15,7 @@ import (
 
 // MetricsScrapingOption adds the scraping endpoint which Prometheus uses to fetch metrics.
 func MetricsScrapingOption(path string) ServeOption {
-	return func(_ API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ api.API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.Handle(path, promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
 		return mux, nil
 	}
@@ -22,7 +23,7 @@ func MetricsScrapingOption(path string) ServeOption {
 
 // This adds collection of OpenCensus metrics
 func MetricsOpenCensusCollectionOption() ServeOption {
-	return func(_ API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ api.API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		log.Info("Init OpenCensus")
 
 		promRegistry := prometheus.NewRegistry()
@@ -51,7 +52,7 @@ func MetricsOpenCensusCollectionOption() ServeOption {
 
 // MetricsCollectionOption adds collection of net/http-related metrics.
 func MetricsCollectionOption(handlerName string) ServeOption {
-	return func(_ API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ api.API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		// Adapted from github.com/prometheus/client_golang/prometheus/http.go
 		// Work around https://github.com/prometheus/client_golang/pull/311
 		opts := prometheus.SummaryOpts{

--- a/mock/directoryitem.go
+++ b/mock/directoryitem.go
@@ -1,0 +1,29 @@
+package mock
+
+type directoryItem struct {
+	Size      string
+	Name      string
+	Path      string
+	Hash      string
+	ShortHash string
+}
+
+func (d *directoryItem) GetSize() string {
+	return d.Size
+}
+
+func (d *directoryItem) GetName() string {
+	return d.Name
+}
+
+func (d *directoryItem) GetPath() string {
+	return d.Path
+}
+
+func (d *directoryItem) GetHash() string {
+	return d.Hash
+}
+
+func (d *directoryItem) GetShortHash() string {
+	return d.ShortHash
+}

--- a/mock/mockapi.go
+++ b/mock/mockapi.go
@@ -2,13 +2,16 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/ipfs-shipyard/gateway-prime/api"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-fetcher"
+	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/storage/memstore"
 )
 
 // API implementation of an API backing a gateway.
@@ -34,9 +37,9 @@ func (m *API) NewSession(context.Context) *ipld.LinkSystem {
 	m.Once.Do(func() {
 		ls := cidlink.DefaultLinkSystem()
 		m.backing = &ls
-		store := memstore.Store{Bag: map[string][]byte{}}
-		ls.SetReadStorage(&store)
-		ls.SetWriteStorage(&store)
+		store := cidlink.Memory{Bag: map[string][]byte{}}
+		ls.StorageReadOpener = store.OpenRead
+		ls.StorageWriteOpener = store.OpenWrite
 	})
 
 	return m.backing
@@ -47,13 +50,31 @@ func (m *API) FetcherForSession(*ipld.LinkSystem) fetcher.Fetcher {
 	return &nilFetcher{m.backing}
 }
 
+// GetUnixFSNode is a special instnace of fetcher for unixfs that allows for alternative
+// fetching strategies based on the semantic intention of getting a direct UnixFS
+// object.
+func (m *API) GetUnixFSNode(ls *ipld.LinkSystem, node cid.Cid) (files.Node, error) {
+	// TODO
+	return nil, nil
+}
+
+// GetUnixFSDir requests the entries of a unixfs directories. This eventaully should be an
+// API on the go-ipfs-files interface, but is included here explictly until all implementations
+// support it directly on Directory objects.
+func (m *API) GetUnixFSDir(*ipld.LinkSystem, files.Directory) ([]api.DirectoryItem, error) {
+	return nil, nil
+}
+
 // Resolve ipns names
 func (m *API) Resolve(_ context.Context, name string) (string, error) {
 	if m.Resolver == nil {
 		return name, nil
 	}
 	if r, ok := m.Resolver[name]; ok {
+		fmt.Printf("did resolve for %s\n", name)
 		return r, nil
+	} else {
+		fmt.Printf("did not resolve for %s\n", name)
 	}
 	if m.ResolverFailures != nil {
 		if e, ok := m.ResolverFailures[name]; ok {

--- a/option_test.go
+++ b/option_test.go
@@ -16,9 +16,11 @@ type testcasecheckversion struct {
 	responseCode int
 }
 
+const testCaseAPIVersion = "/go-ipfs/0.1"
+
 func (tc testcasecheckversion) body() string {
 	if !tc.shouldHandle && tc.responseBody == "" {
-		return fmt.Sprintf("%s (%s)\n", errAPIVersionMismatch, tc.userAgent)
+		return fmt.Sprintf("%s (%s != %s)\n", errAPIVersionMismatch, testCaseAPIVersion, tc.userAgent)
 	}
 
 	return tc.responseBody
@@ -39,7 +41,7 @@ func TestCheckVersionOption(t *testing.T) {
 
 		called := false
 		root := http.NewServeMux()
-		mux, err := CheckVersionOption("/go-ipfs/0.1")(nil, nil, nil, root)
+		mux, err := CheckVersionOption(testCaseAPIVersion)(nil, nil, nil, root)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/redirect.go
+++ b/redirect.go
@@ -3,11 +3,13 @@ package gateway
 import (
 	"net"
 	"net/http"
+
+	"github.com/ipfs-shipyard/gateway-prime/api"
 )
 
 func RedirectOption(path string, redirect string) ServeOption {
 	handler := &redirectHandler{redirect}
-	return func(a API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(a api.API, _ *GatewayConfig, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		if len(path) > 0 {
 			mux.Handle("/"+path+"/", handler)
 		} else {


### PR DESCRIPTION
* Creates an explicit API for backing the HTTP module
* Remove direct dependency of the ipfs core api and other concrete large dependencies
* modifies directory listing behavior, to expose an interface for getting directory item sizes without requesting the full file data.